### PR TITLE
snippet may be used inside jade as !{mangoSnippet}

### DIFF
--- a/lib/mango.js
+++ b/lib/mango.js
@@ -8,6 +8,9 @@ var util = require('util')
 var Mango = module.exports = function(folder, config) {
 	this.config = config || {}
 	this.config.dir = folder
+	if(!this.config.snippetFilename) {
+		this.config.snippetFilename = '.mango-snippet.html'
+	}
 	this.config.devmode = false
 	this.defaultTasks = ['styles', 'scripts', 'templates', 'patternlab', 'images', 'static']
 	this.checkVersion()

--- a/lib/tasks/templates.js
+++ b/lib/tasks/templates.js
@@ -36,6 +36,7 @@ module.exports = function(gulp, config) {
 			return resolve
 		}
 
+
 		if(config.data) {
 			for(key in config.data){
 				var value = config.data[key]
@@ -47,6 +48,8 @@ module.exports = function(gulp, config) {
 				templatesData[key] = value
 			}
 		}
+
+		templatesData.mangoSnippet = false
 
 		var task = gulp.src(config.templates)
 
@@ -62,6 +65,11 @@ module.exports = function(gulp, config) {
 			.pipe(data(function(file) {
 				var name = path.basename(file.path)
 				var data = _.cloneDeep(templatesData)
+
+				var fs = require('fs')
+				if(fs.existsSync(config.snippetFilename)) {
+					data.mangoSnippet = fs.readFileSync(config.snippetFilename, 'utf8')
+				}
 
 				// In case of name == key, assign value as global object
 				if(typeof templatesData[name] !== 'undefined') {

--- a/lib/tasks/watch_reload.js
+++ b/lib/tasks/watch_reload.js
@@ -40,7 +40,7 @@ module.exports = function(gulp, config, watch) {
 
 		// Start a browsersync server
 		browsersync(bsOptions, function(err, bs) {
-			var snippet_filename = '.mango-snippet.html';
+			var snippet_filename = config.snippetFilename;
 			if(config.snippet) {
 				require('fs').writeFile(snippet_filename, bs.getOption('snippet'), function(){
 					process.on('exit', function(){


### PR DESCRIPTION
Useful when static jade templates need some PHP scripts around and you still want live-reload.
