### PR TITLE
Configurable stylus

### DIFF
--- a/lib/tasks/styles.js
+++ b/lib/tasks/styles.js
@@ -18,6 +18,7 @@ module.exports = function(gulp, config) {
 		var sass = require('gulp-sass')
 		var sourcemaps = require('gulp-sourcemaps')
 		var stylus = require('gulp-stylus')
+		var assign = require('lodash/object/assign')
 
 		var filterLess = gulpFilter('**/*.less', { restore: true })
 		var filterSass = gulpFilter('**/*.scss', { restore: true })
@@ -25,13 +26,13 @@ module.exports = function(gulp, config) {
 
 		var task = gulp.src(config.styles, { base: config.src_folder })
 
-		var stylusOptions = {
+		var stylusOptions = assign({}, {
 			use: nib(),
 			define: {
 				debug: config.devmode
 			},
 			'include css': true
-		}
+		}, config.stylus | {})
 
 		// Init sourcemaps and plumber in devmode
 		if(config.devmode){


### PR DESCRIPTION
Use `_.assign` or `_.merge`? I used assign as in https://github.com/manGoweb/mango-cli/commit/7902ad08fe281dced17814ddd9a30f836526046f.