### PR TITLE
watch_sources: multiple handlers for one file type

### DIFF
--- a/lib/tasks/watch_sources.js
+++ b/lib/tasks/watch_sources.js
@@ -49,23 +49,27 @@ module.exports = function(gulp, config, watch) {
 
 			config._lastChanged = filepath
 
-			var handler = false
+			var handlers = []
 
 			Object.keys(mapping).forEach(function (key) {
 
 				mapping[key].forEach(function(regexp) {
 					if(filepath.match(regexp)) {
-						handler = key
+						handlers.push(key)
 					}
 				})
 			})
 
-			if (!handler) {
+			if (!handlers.length) {
 				c.warn('! unknown extension', path.extname(filepath), filepath)
 				return
 			}
 
-			gulp.start(handler, completeHandler)
+			handlers.forEach(function(handler) {
+				gulp.start(handler, completeHandler)
+			})
+
+
 		}
 
 		watch(glob, changeHandler)


### PR DESCRIPTION
Use case: template or stylesheet files can be required into js files
Previous implementation was broken anyway, it executed just last matched handler