### PR TITLE
sass globbing

### DIFF
--- a/lib/tasks/styles.js
+++ b/lib/tasks/styles.js
@@ -16,6 +16,7 @@ module.exports = function(gulp, config) {
 		var plumber = require('gulp-plumber')
 		var postcss = require('gulp-postcss')
 		var sass = require('gulp-sass')
+		var sassGlob = require('gulp-sass-glob')
 		var sourcemaps = require('gulp-sourcemaps')
 		var stylus = require('gulp-stylus')
 		var assign = require('lodash/object/assign')
@@ -47,6 +48,7 @@ module.exports = function(gulp, config) {
 			.pipe(filterStylus.restore)
 		// Sass part
 			.pipe(filterSass)
+			.pipe(sassGlob())
 			.pipe(sass())
 			.pipe(filterSass.restore)
 		// LESS part

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.3",
     "gulp-sass": "^2.3.0-beta.1",
+    "mango-cli-sass-glob": "^1.1.0",
     "gulp-sourcemaps": "^1.2.8",
     "gulp-stylus": "^2.3.0",
     "gulp-uglify": "^1.0.2",


### PR DESCRIPTION
I made tweaked version of `gulp-sass-glob` => `mango-cli-sass-glob` (with pull request to original package), which works with mango-cli... so you can use our beloved stylus glob import...

```
@import "parts/*";
```