### PR TITLE
FIx run-sequence - use gulp

### DIFF
--- a/lib/mango.js
+++ b/lib/mango.js
@@ -191,7 +191,7 @@ Mango.prototype._registerGulpTasks = function(gulp) {
 	gulp.task('watch:patternlab', patternlab_watch)
 
 	// Join build tasks together
-	var runSequence = require('run-sequence')
+	var runSequence = require('run-sequence').use(gulp)
 	gulp.task('compile', function() {
 		runSequence(activeTasks, 'buildstamp')
 	})


### PR DESCRIPTION
Otherwise `Error: Task styles is not configured as a task on gulp.  If this is a submodule, you may need to use require('run-sequence').use(gulp).`