### PR TITLE
Images: fix image resize options overwriting

### DIFF
--- a/lib/tasks/images.js
+++ b/lib/tasks/images.js
@@ -34,7 +34,7 @@ module.exports = function(gulp, config) {
 		task.add(gulp.src(glob, { base: config.src_folder, cwd: config.dir }))
 		// Pipe images, which has to be transformed
 		for (var i = 0; i < imageObjects.length; i++) {
-			var image = imageObjects[i]
+			const image = imageObjects[i]
 			task.add(gulp.src(image.src, { base: config.src_folder, cwd: config.dir })
 				.pipe(function () {
 					var transformStream = new stream.Transform({objectMode: true})


### PR DESCRIPTION
When having multiple images to resize with different target sizes, `mango-cli` was overwriting configs by the last one. This PR is fixing that.