### PR TITLE
decorators support

### DIFF
--- a/example/frontbase/js/index-next.es6
+++ b/example/frontbase/js/index-next.es6
@@ -1,2 +1,15 @@
 let $ = require('jquery')
 let plugins = require('./plugins')
+
+class TestClass {
+	
+}
+
+function decorator() {
+	return x => x
+}
+
+@decorator
+class DecoratedTestClass {
+	
+}

--- a/lib/tasks/scripts.js
+++ b/lib/tasks/scripts.js
@@ -18,7 +18,9 @@ module.exports = function(gulp, config) {
 			var result = babel.transform(code, {
 				sourceMap: config.devmode,
 				filename: opts.localFilename,
-				highlightCode: false
+				highlightCode: false,
+				presets: [ "latest" ],
+				plugins: ["transform-decorators-legacy"]
 			})
 
 			return { code: result.code, sourceMap: JSON.stringify(result.map) }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
   "homepage": "https://github.com/manGoweb/mango-cli",
   "dependencies": {
     "autoprefixer": "^6.3.1",
-    "babel-core": "^5.8.25",
+    "babel-core": "^6.17.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-preset-latest": "^6.16.0",
     "better-console": "^0.2.3",
     "browser-sync": "^2.11.1",
     "chokidar": "^1.0.1",


### PR DESCRIPTION
updated Babel to version 6 with preset "latest" and using legacy decorators.

The version update might break something, so please test it :)
