### PR TITLE
Add Docker builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-mango-cli [![CircleCI](https://circleci.com/gh/manGoweb/mango-cli/tree/master.svg?style=svg)](https://circleci.com/gh/manGoweb/mango-cli/tree/master) [![Build Status](https://travis-ci.org/manGoweb/mango-cli.svg?branch=master)](https://travis-ci.org/manGoweb/mango-cli) [![Build status](https://ci.appveyor.com/api/projects/status/vwqy0au8l17xlmt9/branch/master?svg=true)](https://ci.appveyor.com/project/enzy/mango-cli/branch/master) [![NPM downloads](https://img.shields.io/npm/dm/mango-cli.svg)](https://www.npmjs.com/package/mango-cli) 
+mango-cli [![CircleCI](https://circleci.com/gh/manGoweb/mango-cli/tree/master.svg?style=svg)](https://circleci.com/gh/manGoweb/mango-cli/tree/master) [![Build Status](https://travis-ci.org/manGoweb/mango-cli.svg?branch=master)](https://travis-ci.org/manGoweb/mango-cli) [![Build status](https://ci.appveyor.com/api/projects/status/vwqy0au8l17xlmt9/branch/master?svg=true)](https://ci.appveyor.com/project/enzy/mango-cli/branch/master) [![NPM downloads](https://img.shields.io/npm/dm/mango-cli.svg)](https://www.npmjs.com/package/mango-cli)
 =========
 
 [mangoweb.github.io/mango](http://mangoweb.github.io/mango)
@@ -136,4 +136,4 @@ More in [Configuration options](docs/config.md) docs...
 
 ## Copyright
 
-Copyright 2016 by [manGoweb s.r.o.](http://www.mangoweb.cz) Code released under [the MIT license](LICENSE). Evolved from [Frontbase](http://frontbase.org) devstack.
+Copyright 2016-2017 [manGoweb s.r.o.](https://www.mangoweb.cz) Code released under [the MIT license](LICENSE). Evolved from [Frontbase](http://frontbase.org) devstack.

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,22 @@
 machine:
+  services:
+    - docker
   node:
     version: 7
+  environment:
+    DOCKER_EMAIL: mikulas@mangoweb.cz
+    DOCKER_USER: mangobot
+    # DOCKER_PASS is private and set in CircleCI admin
+
+deployment:
+  dockerhub:
+    branch: deploy/dockerhub
+    commands:
+      - docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS"
+      - cd docker && make build dockerhub
+  ecr:
+    branch: deploy/ecr
+    commands:
+      - aws configure set default.region eu-west-1
+      - $(aws ecr get-login)
+      - cd docker && make build aws

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:7
+
+MAINTAINER mangoweb
+
+RUN npm install -g https://github.com/manGoweb/mango-cli.git#deploy/dockerhub
+
+ENV HOST_MOUNT /usr/src/build
+VOLUME [$HOST_MOUNT]
+WORKDIR $HOST_MOUNT
+
+ENTRYPOINT ["mango"]
+CMD ["build"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,22 @@
+_: build
+
+IMAGE="mango-cli"
+ECR="831119889470.dkr.ecr.eu-west-1.amazonaws.com"
+
+build:
+	docker build -t ${IMAGE} .
+
+aws: aws-tag aws-push
+aws-tag:
+	docker tag ${IMAGE}:latest ${ECR}/${IMAGE}:latest
+aws-push:
+	docker push ${ECR}/${IMAGE}:latest
+
+dockerhub: dockerhub-tag dockerhub-push
+dockerhub-tag:
+	docker tag ${IMAGE}:latest mangoweb/${IMAGE}:latest
+dockerhub-push:
+	docker push mangoweb/${IMAGE}:latest
+
+
+.PHONY: build aws aws-tag aws-push dockerhub dockerhub-tag dockerhub-push


### PR DESCRIPTION
Pushes to `deploy/dockerhub` automatically build the container and tags as `latest`.

https://hub.docker.com/r/mangoweb/mango-cli/

To build mango project in current directory:

```
docker run -it --rm --name my_mango_build --dns=8.8.8.8 \
  -v "$PWD":/usr/src/app -w /usr/src/app \
  mangoweb/mango-cli:latest
```

TODO: 
- [x] properly tag with release versions
- [x] use generic credentials (not mine)
- [ ] <del>configure CI cache</del>