### PR TITLE
Add babel support for typescript

### DIFF
--- a/lib/tasks/scripts.js
+++ b/lib/tasks/scripts.js
@@ -19,8 +19,8 @@ module.exports = function(gulp, config) {
 				sourceMap: config.devmode,
 				filename: opts.localFilename,
 				highlightCode: false,
-				presets: [ "babel-preset-latest" ].map(require.resolve),
-				plugins: [ "babel-plugin-transform-decorators-legacy", "babel-plugin-transform-class-properties", "babel-plugin-transform-react-jsx", "babel-plugin-transform-object-rest-spread" ].map(require.resolve), // as Babel looks for a plugin
+				presets: [ "babel-preset-env", "babel-preset-typescript" ].map(require.resolve),
+				plugins: [ "babel-plugin-transform-decorators-legacy", "babel-plugin-transform-class-properties", "babel-plugin-transform-react-jsx", "babel-plugin-transform-object-rest-spread"].map(require.resolve), // as Babel looks for a plugin
 			})
 
 			return { code: result.code, sourceMap: JSON.stringify(result.map) }
@@ -36,6 +36,7 @@ module.exports = function(gulp, config) {
 		task = task.pipe(webmake({
 				'ext': [
 					'coffee',
+					{ name: 'BabelTypescript', extension: 'ts', type: 'js', compile: babelTransform },
 					{ name: 'BabelJSX', extension: 'jsx', type: 'js', compile: babelTransform },
 					{ name: 'BabelES6', extension: 'es6', type: 'js', compile: babelTransform },
 					{ name: 'BabelES', extension: 'es', type: 'js', compile: babelTransform }

--- a/lib/tasks/watch_sources.js
+++ b/lib/tasks/watch_sources.js
@@ -1,6 +1,6 @@
 var mappingDefaults = {
 	styles: ['css', 'less', 'scss', 'sass', 'styl'],
-	scripts: ['js', 'jsx', 'es6', 'es', 'coffee'],
+	scripts: ['js', 'jsx', 'es6', 'es', 'coffee', 'ts'],
 	templates: ['jade', 'pug', 'json', 'html', 'htm'],
 	images: ['jpg', 'jpeg', 'png', 'svg'],
 	sprites: ['svg']
@@ -10,7 +10,7 @@ var mappingDefaults = {
 module.exports = function(gulp, config, watch) {
 	var mapping = require('lodash').merge({}, mappingDefaults, config.mapping || {})
 
-	var fileExtensions = ['css','styl','scss','sass','less','js','jsx','es6','es','coffee','jade','pug','json','html','htm']
+	var fileExtensions = []
 	var mappingRegEx = {}
 	Object.keys(mapping).forEach(function(key) {
 		mappingRegEx[key] = []

--- a/package-lock.json
+++ b/package-lock.json
@@ -397,207 +397,314 @@
       }
     },
     "babel-core": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
-      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+      "version": "7.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-alpha.19.tgz",
+      "integrity": "sha512-F7/vos5H4N5Mv+TZU1CgJ/zJ5bk4JXK83YC+zqhhURH6muxnRKgWYWkVbqVTLmHUrwVn8GCufQdkpAQ3tNPeJA==",
       "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-generator": "6.25.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.4",
+        "babel-code-frame": "7.0.0-alpha.19",
+        "babel-generator": "7.0.0-alpha.19",
+        "babel-helpers": "7.0.0-alpha.19",
+        "babel-messages": "7.0.0-alpha.19",
+        "babel-template": "7.0.0-alpha.19",
+        "babel-traverse": "7.0.0-alpha.19",
+        "babel-types": "7.0.0-alpha.19",
+        "babylon": "7.0.0-beta.19",
         "convert-source-map": "1.5.0",
         "debug": "2.6.8",
         "json5": "0.5.1",
         "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
-        "slash": "1.0.0",
+        "micromatch": "2.3.11",
+        "resolve": "1.3.3",
         "source-map": "0.5.6"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "babel-code-frame": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-+eEVwCwCRd4drQsKQZ1Uim0ECzNJUjgxEx+mdTxh6JX6mqNjjKbbdJMe4zn3QtsK8eiCHJawt2UjxhisH3+tog==",
+          "requires": {
+            "chalk": "2.1.0",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-generator": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-G3/pJeI3V6dOR7ztt9qeRDqgBc8l5iovb7B1RUFJNDmGb8ZlcGkYyeKv7PEPtIprcbgOKc13yWx3xKc5UbUi7w==",
+          "requires": {
+            "babel-messages": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19",
+            "jsesc": "2.5.1",
+            "lodash": "4.17.4",
+            "source-map": "0.5.6",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-RBrnSG/Y6fI1HuCc2t1q1bBOcWRK8vvRzzthjfBKhQBrDWJBa86r8EvbqTJUnYl2qOUtY9D8djdhTBL2uvit5Q==",
+          "requires": {
+            "babel-helper-get-function-arity": "7.0.0-alpha.19",
+            "babel-template": "7.0.0-alpha.19",
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-j46M8BCNsllimyHR0uejSM70h0/P0DVOgm02ul+OQ3gurXhdQ1SFmD/VDabBPu6GTLR/UwdCB8olkzc64r3i5g==",
+          "requires": {
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-helpers": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-2AdJGQ+HK0tbYAAbVw+yudMQnZI6SOl/a2EuJYA066SfycE6bfN6F+KG9z2A7N2PlljEFrosawHKL1qNQsG8hg==",
+          "requires": {
+            "babel-template": "7.0.0-alpha.19"
+          }
+        },
+        "babel-messages": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-uvK8YhgjYrKQGZchyI8fGPQBddQSPmX2PcVG5CombkNONzL4i916LxnjhusQoZRi9FGNIe7C/UANDOlWEX3Qjw=="
+        },
+        "babel-template": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-96IEIj99ubXPjZyF2V/ZZrjSUAO3baNtOP16Qlibd9q5Hh4WVm+Xv2mOqdjABJG96N991EAtNXk3+JibJGxnWQ==",
+          "requires": {
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19",
+            "babylon": "7.0.0-beta.18",
+            "lodash": "4.17.4"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "7.0.0-beta.18",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.18.tgz",
+              "integrity": "sha1-XCPuP9tmNYqr83iXeTGcW3iiM8c="
+            }
+          }
+        },
+        "babel-traverse": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-nW2yJJjVTKnvmqWSh8jsUAJaQMhTDhD4CPdy7hLhOTxGORPKP+V5ax8wQCHhIbgU+lV2oJ9iqJUpvGvjs7GRwA==",
+          "requires": {
+            "babel-code-frame": "7.0.0-alpha.19",
+            "babel-helper-function-name": "7.0.0-alpha.19",
+            "babel-messages": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19",
+            "babylon": "7.0.0-beta.19",
+            "debug": "2.6.8",
+            "globals": "10.1.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "2.0.0"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.19",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+          "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A=="
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.2.1"
+          }
+        },
+        "globals": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.1.0.tgz",
+          "integrity": "sha1-RCWhiBvg0za0qCOoKnvnJdXdmHw="
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
         }
       }
     },
-    "babel-generator": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-      "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+    "babel-helper-wrap-function": {
+      "version": "7.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/babel-helper-wrap-function/-/babel-helper-wrap-function-7.0.0-alpha.19.tgz",
+      "integrity": "sha512-Vf0gzM3wOFEB6aJhnqFdR+bfmn53q2YOvQxQL7x2LQ85GSJdHyY3OVh+//hv/pOAdfdyD/2oJKNYK4wGJZtbtg==",
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.6",
-        "trim-right": "1.0.1"
+        "babel-helper-function-name": "7.0.0-alpha.19",
+        "babel-template": "7.0.0-alpha.19",
+        "babel-traverse": "7.0.0-alpha.19",
+        "babel-types": "7.0.0-alpha.19"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "babel-code-frame": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-+eEVwCwCRd4drQsKQZ1Uim0ECzNJUjgxEx+mdTxh6JX6mqNjjKbbdJMe4zn3QtsK8eiCHJawt2UjxhisH3+tog==",
+          "requires": {
+            "chalk": "2.1.0",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-RBrnSG/Y6fI1HuCc2t1q1bBOcWRK8vvRzzthjfBKhQBrDWJBa86r8EvbqTJUnYl2qOUtY9D8djdhTBL2uvit5Q==",
+          "requires": {
+            "babel-helper-get-function-arity": "7.0.0-alpha.19",
+            "babel-template": "7.0.0-alpha.19",
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-j46M8BCNsllimyHR0uejSM70h0/P0DVOgm02ul+OQ3gurXhdQ1SFmD/VDabBPu6GTLR/UwdCB8olkzc64r3i5g==",
+          "requires": {
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-messages": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-uvK8YhgjYrKQGZchyI8fGPQBddQSPmX2PcVG5CombkNONzL4i916LxnjhusQoZRi9FGNIe7C/UANDOlWEX3Qjw=="
+        },
+        "babel-template": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-96IEIj99ubXPjZyF2V/ZZrjSUAO3baNtOP16Qlibd9q5Hh4WVm+Xv2mOqdjABJG96N991EAtNXk3+JibJGxnWQ==",
+          "requires": {
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19",
+            "babylon": "7.0.0-beta.18",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-nW2yJJjVTKnvmqWSh8jsUAJaQMhTDhD4CPdy7hLhOTxGORPKP+V5ax8wQCHhIbgU+lV2oJ9iqJUpvGvjs7GRwA==",
+          "requires": {
+            "babel-code-frame": "7.0.0-alpha.19",
+            "babel-helper-function-name": "7.0.0-alpha.19",
+            "babel-messages": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19",
+            "babylon": "7.0.0-beta.19",
+            "debug": "2.6.8",
+            "globals": "10.1.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "7.0.0-beta.19",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+              "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A=="
+            }
+          }
+        },
+        "babel-types": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "2.0.0"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.18",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.18.tgz",
+          "integrity": "sha1-XCPuP9tmNYqr83iXeTGcW3iiM8c="
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.2.1"
+          }
+        },
+        "globals": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.1.0.tgz",
+          "integrity": "sha1-RCWhiBvg0za0qCOoKnvnJdXdmHw="
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
         }
-      }
-    },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-builder-react-jsx": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
-      "integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "esutils": "2.0.2"
-      }
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-define-map": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        }
-      }
-    },
-    "babel-helper-explode-assignable-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        }
-      }
-    },
-    "babel-helper-remap-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
       }
     },
     "babel-messages": {
@@ -608,68 +715,160 @@
         "babel-runtime": "6.23.0"
       }
     },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
-    },
-    "babel-plugin-syntax-class-properties": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
-    },
     "babel-plugin-syntax-decorators": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
       "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
     },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
-    },
-    "babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
-    },
     "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+      "version": "7.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-7.0.0-alpha.19.tgz",
+      "integrity": "sha512-Jo9wXmU9AtufOFPdQpedc+j7Ck5okGYsK0zkk2NZNae61SAtuMF5M3aRUeZusrssPqWC32pOiBokbApIFHdlXw=="
     },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-    },
-    "babel-plugin-transform-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.23.0"
-      }
+    "babel-plugin-syntax-typescript": {
+      "version": "7.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-typescript/-/babel-plugin-syntax-typescript-7.0.0-alpha.19.tgz",
+      "integrity": "sha512-jLuaWfoQsVr8/hmZtWB+86tZ5jYmOYV6kq70EkSUT7RR+gfeYOExS0FjObbbp+WExZNpBaRZvlyikNk3hCQGeQ=="
     },
     "babel-plugin-transform-class-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "version": "7.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-7.0.0-alpha.19.tgz",
+      "integrity": "sha512-fM4Ls8MMeiqIrEaLwIzysiZuXF7k1C1ra7QurlN4FtQYh6BGMB9u2+FvDCRaI2n+Nl0Q9Dawl5lRrjjoEazUVA==",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
+        "babel-helper-function-name": "7.0.0-alpha.19",
+        "babel-plugin-syntax-class-properties": "7.0.0-alpha.19",
+        "babel-template": "7.0.0-alpha.19"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "babel-code-frame": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-+eEVwCwCRd4drQsKQZ1Uim0ECzNJUjgxEx+mdTxh6JX6mqNjjKbbdJMe4zn3QtsK8eiCHJawt2UjxhisH3+tog==",
+          "requires": {
+            "chalk": "2.1.0",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-RBrnSG/Y6fI1HuCc2t1q1bBOcWRK8vvRzzthjfBKhQBrDWJBa86r8EvbqTJUnYl2qOUtY9D8djdhTBL2uvit5Q==",
+          "requires": {
+            "babel-helper-get-function-arity": "7.0.0-alpha.19",
+            "babel-template": "7.0.0-alpha.19",
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-j46M8BCNsllimyHR0uejSM70h0/P0DVOgm02ul+OQ3gurXhdQ1SFmD/VDabBPu6GTLR/UwdCB8olkzc64r3i5g==",
+          "requires": {
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-messages": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-uvK8YhgjYrKQGZchyI8fGPQBddQSPmX2PcVG5CombkNONzL4i916LxnjhusQoZRi9FGNIe7C/UANDOlWEX3Qjw=="
+        },
+        "babel-plugin-syntax-class-properties": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-9ED3fO2ETTkAA8hXSSazQ/zgHemiky3qHQ6b9qME6cq1Iht6du50ETb2UkPNQKVTVXYnx5AmRKcIOfU8JMUqzg=="
+        },
+        "babel-template": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-96IEIj99ubXPjZyF2V/ZZrjSUAO3baNtOP16Qlibd9q5Hh4WVm+Xv2mOqdjABJG96N991EAtNXk3+JibJGxnWQ==",
+          "requires": {
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19",
+            "babylon": "7.0.0-beta.18",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-nW2yJJjVTKnvmqWSh8jsUAJaQMhTDhD4CPdy7hLhOTxGORPKP+V5ax8wQCHhIbgU+lV2oJ9iqJUpvGvjs7GRwA==",
+          "requires": {
+            "babel-code-frame": "7.0.0-alpha.19",
+            "babel-helper-function-name": "7.0.0-alpha.19",
+            "babel-messages": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19",
+            "babylon": "7.0.0-beta.19",
+            "debug": "2.6.8",
+            "globals": "10.1.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "7.0.0-beta.19",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+              "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A=="
+            }
+          }
+        },
+        "babel-types": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "2.0.0"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.18",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.18.tgz",
+          "integrity": "sha1-XCPuP9tmNYqr83iXeTGcW3iiM8c="
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.2.1"
+          }
+        },
+        "globals": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.1.0.tgz",
+          "integrity": "sha1-RCWhiBvg0za0qCOoKnvnJdXdmHw="
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        }
       }
     },
     "babel-plugin-transform-decorators-legacy": {
@@ -682,348 +881,579 @@
         "babel-template": "6.25.0"
       }
     },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "7.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-7.0.0-alpha.19.tgz",
+      "integrity": "sha512-2qNW0p2agGtSIGTFaZo50hK5ZSRRCBn5iwz3NFI/CdRk4KQIyaJOsJ3HGRZK8aPpjjXYSuil2FTSc3JciN90ww==",
       "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
+        "babel-plugin-syntax-object-rest-spread": "7.0.0-alpha.19"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        "babel-plugin-syntax-object-rest-spread": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-Jo9wXmU9AtufOFPdQpedc+j7Ck5okGYsK0zkk2NZNae61SAtuMF5M3aRUeZusrssPqWC32pOiBokbApIFHdlXw=="
         }
-      }
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "requires": {
-        "babel-helper-define-map": "6.24.1",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "regexpu-core": "2.0.0"
-      }
-    },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-object-rest-spread": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
-      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-react-jsx": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
-      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+      "version": "7.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-7.0.0-alpha.19.tgz",
+      "integrity": "sha512-LxAD8wYZ6AwbObQr6WkpVkzRbi4hFoDZO5q4BsqmYSSOpOetY1QxykopXWv0Lhycbc5pT/nsfhsmTUK4PH81pw==",
       "requires": {
-        "babel-helper-builder-react-jsx": "6.24.1",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.23.0"
-      }
-    },
-    "babel-plugin-transform-regenerator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
-      "requires": {
-        "regenerator-transform": "0.9.11"
-      }
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
-    },
-    "babel-preset-es2015": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.24.1"
-      }
-    },
-    "babel-preset-es2016": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2016/-/babel-preset-es2016-6.24.1.tgz",
-      "integrity": "sha1-+QC/k+LrwNJ235uKtZck6/2Vn4s=",
-      "requires": {
-        "babel-plugin-transform-exponentiation-operator": "6.24.1"
-      }
-    },
-    "babel-preset-es2017": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2017/-/babel-preset-es2017-6.24.1.tgz",
-      "integrity": "sha1-WXvq37n38gi8/YoS6bKym4svFNE=",
-      "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1"
-      }
-    },
-    "babel-preset-latest": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-latest/-/babel-preset-latest-6.24.1.tgz",
-      "integrity": "sha1-Z33gaRVKdIXC0lxXfAL2JLhbheg=",
-      "requires": {
-        "babel-preset-es2015": "6.24.1",
-        "babel-preset-es2016": "6.24.1",
-        "babel-preset-es2017": "6.24.1"
-      }
-    },
-    "babel-register": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-      "requires": {
-        "babel-core": "6.25.0",
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.15"
+        "babel-helper-builder-react-jsx": "7.0.0-alpha.19",
+        "babel-plugin-syntax-jsx": "7.0.0-alpha.19"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        "babel-helper-builder-react-jsx": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-sYOBUa6lc1garR7YD+aQfNXTFq9YJ78z1fx+h5WuipqBkFYIOMf7mBpxJPg0/a5rVfOT8TEyEqCZPqFg6otNrA==",
+          "requires": {
+            "babel-types": "7.0.0-alpha.19",
+            "esutils": "2.0.2"
+          }
+        },
+        "babel-plugin-syntax-jsx": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-xQEWRBNZ+W594GFZ6ipoeDfjlk5w0/KqIjSe942gCnFGvOwqh3cFGbdA996ldgRf5bjvRlCs9WTwdSW2SmqAlA=="
+        },
+        "babel-types": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
         }
+      }
+    },
+    "babel-plugin-transform-typescript": {
+      "version": "7.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-typescript/-/babel-plugin-transform-typescript-7.0.0-alpha.19.tgz",
+      "integrity": "sha512-OtkOYcYRffmC38/UjDZn2cvM2qarqDT748TbSJtVpNb7EvDLQcfPn9+0adk8oqmhc0lk+Ldy/2daGMNMxW0vuQ==",
+      "requires": {
+        "babel-plugin-syntax-typescript": "7.0.0-alpha.19"
+      }
+    },
+    "babel-preset-env": {
+      "version": "2.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-2.0.0-alpha.19.tgz",
+      "integrity": "sha512-Q1CoVeetTZJcjYHUhCqisOdJ/q2gNAXAgs8KxAo7WJIPBs6Tgb1WRbuMzirhQqXHLS4r5q/AofaFaP6p+vKSlg==",
+      "requires": {
+        "babel-plugin-check-es2015-constants": "7.0.0-alpha.19",
+        "babel-plugin-syntax-trailing-function-commas": "7.0.0-alpha.19",
+        "babel-plugin-transform-async-to-generator": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-arrow-functions": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-block-scoped-functions": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-block-scoping": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-classes": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-computed-properties": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-destructuring": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-duplicate-keys": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-for-of": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-function-name": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-literals": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-modules-amd": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-modules-commonjs": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-modules-systemjs": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-modules-umd": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-object-super": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-parameters": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-shorthand-properties": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-spread": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-sticky-regex": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-template-literals": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-typeof-symbol": "7.0.0-alpha.19",
+        "babel-plugin-transform-es2015-unicode-regex": "7.0.0-alpha.19",
+        "babel-plugin-transform-exponentiation-operator": "7.0.0-alpha.19",
+        "babel-plugin-transform-regenerator": "7.0.0-alpha.19",
+        "browserslist": "2.3.3",
+        "invariant": "2.2.2",
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "babel-code-frame": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-+eEVwCwCRd4drQsKQZ1Uim0ECzNJUjgxEx+mdTxh6JX6mqNjjKbbdJMe4zn3QtsK8eiCHJawt2UjxhisH3+tog==",
+          "requires": {
+            "chalk": "2.1.0",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-helper-builder-binary-assignment-operator-visitor": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-Kgzqk2IE3ZZfIT4q1t9wYXof6UdyWeMKSvaZ3CCdl7LK/d0fZ40INuMraTJM7KIfkzNLBZ3orbJ+XT1wh6gYJA==",
+          "requires": {
+            "babel-helper-explode-assignable-expression": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-helper-call-delegate": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-V4Yw9Ycqv9/u/E2Sulr3kR03gix5HDnU1agd4E4TmMXd/43zmPmss4KfN10dt6uCW8gzc0QJR5FtgUgTda/49g==",
+          "requires": {
+            "babel-helper-hoist-variables": "7.0.0-alpha.19",
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-helper-define-map": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-c5V4TbjIqXoK2zYC4s1Il59/KQVOnpWrdcv47M9OjKBIv8cfzWcfBeFoNGSojxOr5r1dUdDMK2jeYv8EAyk+Rg==",
+          "requires": {
+            "babel-helper-function-name": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-helper-explode-assignable-expression": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-cZ+QtUivFrjS57zrlnmnA8vYs03l5gYXIhy3NWit1rYKmjJGOsQ3VLEulGRtdicgcEQtU0WWk2uVUnyT1HAVmg==",
+          "requires": {
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-RBrnSG/Y6fI1HuCc2t1q1bBOcWRK8vvRzzthjfBKhQBrDWJBa86r8EvbqTJUnYl2qOUtY9D8djdhTBL2uvit5Q==",
+          "requires": {
+            "babel-helper-get-function-arity": "7.0.0-alpha.19",
+            "babel-template": "7.0.0-alpha.19",
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-j46M8BCNsllimyHR0uejSM70h0/P0DVOgm02ul+OQ3gurXhdQ1SFmD/VDabBPu6GTLR/UwdCB8olkzc64r3i5g==",
+          "requires": {
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-helper-hoist-variables": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-9swiDoVZD6qL7dMDb/tysYmZIKvXY38xohvsLqZN1A8jIaDk8nybWkt+bZwsT00VSaeBJo4/YP7ERjXf2/Tj1w==",
+          "requires": {
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-helper-optimise-call-expression": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-SP7vqqjhZcvzwu5P/Xrr2So8aSBtwwCjQu5aOmjZgq2/HIkIfpqOdz6ud6B5g7I/mfQvE81EWM8qfCUSstdPyA==",
+          "requires": {
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-helper-regex": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-3xJn9/GgIArETMkxm6+sA8XuLMDittJYZI9bY0iwDc8Vp6ChDJ+jHsSDSjpPti0o7zBkecIeyaNAjVktRKgCcw==",
+          "requires": {
+            "babel-types": "7.0.0-alpha.19",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-helper-remap-async-to-generator": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-WQ7yQA2jk1OFL4lVL6t250rXfqGaMSQ1UJHQSx91N9QVUw/JNkRx3NBAo2iypEXWFFBQ1GvdEns0SZ4XjqEaOw==",
+          "requires": {
+            "babel-helper-wrap-function": "7.0.0-alpha.19",
+            "babel-template": "7.0.0-alpha.19",
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-helper-replace-supers": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-/lofcpgP/OaommQKeMD3GSNQjAQIYJr9SARkaA7OPkChP0x4p4EnU1PF77hfDy04N69VnAfCYhrojJLB4mekhg==",
+          "requires": {
+            "babel-helper-optimise-call-expression": "7.0.0-alpha.19",
+            "babel-messages": "7.0.0-alpha.19",
+            "babel-template": "7.0.0-alpha.19",
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-messages": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-uvK8YhgjYrKQGZchyI8fGPQBddQSPmX2PcVG5CombkNONzL4i916LxnjhusQoZRi9FGNIe7C/UANDOlWEX3Qjw=="
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-xOzUuP2Rt261qBlwK/3lPOWqE5NOFN2wNYDUdEy5ENelLwuFEglAbnn33Lo/AvY7QXzvrHAjCxmfHEbF5Z1dkQ=="
+        },
+        "babel-plugin-syntax-async-functions": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-8TrgRevIg/m3wCZNbUpr4FZgRzK5L91MLP6zchVWWR4mx/iRGR+Pg0Ubqg8YHk/kcpqVt5+aF2vteUEeIyONYQ=="
+        },
+        "babel-plugin-syntax-exponentiation-operator": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-IGC73y9d7VMTadK+U5J3O25XPyQGw5PN8m4jkBJbqJratzxeukgLx6uw9FgV07bGu5hudmZSsY7bd4GswnRQwA=="
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-3QfJjQdzi2IERdmrEAoOdPPROX5jx2pnqh9Ao4qr3NGx8j9XnfTpIF/YRBu/P1PtaDCtTT8Mtw7AH72QKPr7kQ=="
+        },
+        "babel-plugin-transform-async-to-generator": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-T4IKT0P32yEp0TCUGttOJsIcfiHBfc4fYO96CYF3tVYaCBbinzYluo4THNSffLDmVDRr7N1ZYFG/jE7jGyWjWw==",
+          "requires": {
+            "babel-helper-remap-async-to-generator": "7.0.0-alpha.19",
+            "babel-plugin-syntax-async-functions": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-yrf4c+1IUUJptxlXKN2pnd9ebT6+ctmOQHAiwX1IEGQUMWSoffhybElAPcykR6MVZUzj1Fcb508wqEoBH8DZcw=="
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-JQ2Q6YrQuw1UdAb4Ol12AIxv5i1mC5Le6ACOK/o3I36zxS3MQEWzIOpm86We7jN6ZYVHT9HI9oqjJrapXgLyKA=="
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-ezJuaiWwF3Yly8GO+AByhb2MyqbSZ0QeT7mkjyysyHnefrqUDjy0Bt0hdHaoNBGr9PB/m/fI/5+F6MpFNJCzwQ==",
+          "requires": {
+            "babel-template": "7.0.0-alpha.19",
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-RF2TjLSh0+BbNvl+WeWdrLSKiW9ebO1/5rAsPFI1m+I4eC3DXWBFpKyqTZX/cdd9JAOpL5RMEtdp3FvXagBI2Q==",
+          "requires": {
+            "babel-helper-define-map": "7.0.0-alpha.19",
+            "babel-helper-function-name": "7.0.0-alpha.19",
+            "babel-helper-optimise-call-expression": "7.0.0-alpha.19",
+            "babel-helper-replace-supers": "7.0.0-alpha.19",
+            "babel-messages": "7.0.0-alpha.19",
+            "babel-template": "7.0.0-alpha.19",
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-4Y/ebvp+62ROaz6yQe9Xj5h6Z/XphuFyFgT7uwGO3X6Zr9hfLi4bjymTVQUT52EPhO2MA+JgwTbcSMLSR8ZZng==",
+          "requires": {
+            "babel-template": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-9kcQAwAOkEBH9EQxrC14LUX+S6yPoexgbiC8EjMVx0MlPqcEkRU49PZOmYqPJg6yoV7wiR7OHyb1tw7kzSNZzQ=="
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-w+BeaxZWXbSEZM8UiX97RAIy6NhL1re9xwJzmi/94tA4O0EgohGD6e0O3VpzMLB90R1uoksmwD+PcnqPx0Gscg==",
+          "requires": {
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-tcK8FnU1wXfvYoy/1QjnVaPGZGkLay+m0B3qSr+JzLzWlekiZBei9M2A6PL2b5h4E6pIQs2VYHFl+dRqO2NQ/A=="
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-5mpEyaP2iTlJJKCmazJaK+cogPDa4rdF9NX3wlmUhA47oRNe9vtvEnZPCkG6gxwNz9G672rmjXmXpap07PEp6A==",
+          "requires": {
+            "babel-helper-function-name": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-Sd1TGhE7EGb1JqFcw1bkhINu+WFXVmzirtfdYyuVyLDQDJpsmF8E2lhdeCtWK9ZreFEV1335Y4z5VoMyZV7+QA=="
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-vFrFDtXn3iyHysYwXpaNJv3xV4YSWT5/LAxZTOpJHisZTEyueNe7akIrsZdWR0S3PnVBMOZVpWS2uD3i9Fyv2Q==",
+          "requires": {
+            "babel-plugin-transform-es2015-modules-commonjs": "7.0.0-alpha.19",
+            "babel-template": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-DIRp/vKPxcQiVhxcsWKjBtag3weJl9wanliUNdNqTyCD0+5fLAIKLqONU8CasPr5OH2uSfCMRo6w7BF3bzO7Dg==",
+          "requires": {
+            "babel-plugin-transform-strict-mode": "7.0.0-alpha.19",
+            "babel-template": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-E0u/sEI6B6d1TFFW4v1bEJlFNm8a6RicsNyy3bIpRvS8wtY5RVXKEaqn7ZgzXBBPgBciiqn/JrQMrpMtr75fZQ==",
+          "requires": {
+            "babel-helper-hoist-variables": "7.0.0-alpha.19",
+            "babel-template": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-9CVtEzzqj64x9PPeBXzOPKYxRos4u8Z0b1LWWI/K7BEIHWL91C07RLCLYAwnOec9jAU3oy64/gysOjW8i3hwsQ==",
+          "requires": {
+            "babel-plugin-transform-es2015-modules-amd": "7.0.0-alpha.19",
+            "babel-template": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-5SUB8zZH5j1omVktHXVzVGMhmC/yokWTFixJZ0CqSRuAwoFTuaBgHsj/T1QtmMZbvrJ3PsV8uCrg8zO7Z2yUgw==",
+          "requires": {
+            "babel-helper-replace-supers": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-+Zq3JmnJmfM+bVURFDkwhSdu9rOrkSAtc8ePdnOMYQTCBsUhnujJMZWWylS/N1KL8oDAK/2dolk9iUisV1SnGw==",
+          "requires": {
+            "babel-helper-call-delegate": "7.0.0-alpha.19",
+            "babel-helper-get-function-arity": "7.0.0-alpha.19",
+            "babel-template": "7.0.0-alpha.19",
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-j5LhWZWZYP4OTiaigQQmoXmLE0k450T4j5e2fJWhBsz5WKq2YSnS0BwHAtlvDH5xFJ6julhbAxf0iWzTmDAbFA==",
+          "requires": {
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-GYX7PRyY0cs+/yl3DBfUxlL2KJ0FQ9D97cxLeRjw6eiz0ql5fuzsIWwhDie7/ccqSNec56E+d/L/z4mvnHabMg=="
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-vdwlh1UD3UTdCBiRmNXensfRO/v3J6VyiIHx7HePnwGRS3Dh8+ePOptdSD8jR9ucC9sAbb/0fkK7tV+jo7I7Tg==",
+          "requires": {
+            "babel-helper-regex": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-bPI0ZJ1nOGzLKjKb0aRgAzYzhEO2yji/3HBoOaD7t0frCOV7eWYDexHrZEMWXDD5DtylzIiCjYQvb2VnbYC8Fg=="
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-d0ishyCrWuTCmU6FRsKUaH/jZcirNC6478eldvvwV0Ufj8g0LRP2HvYq3j8B4ismtceRINfWIZ6D4mEla385gQ=="
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-Co4zk9kF6wxPm+8MKN1hzgCDOY/Ewd24odfCmMzbsXaqqeh3cShF/8gBNuewHGca1m3Hl22zVxaWyXswJ0MwHA==",
+          "requires": {
+            "babel-helper-regex": "7.0.0-alpha.19",
+            "regexpu-core": "4.1.2"
+          }
+        },
+        "babel-plugin-transform-exponentiation-operator": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-AA7SV7XYusZtbxd4wc7ivLdXIZFVmjKBErZVN6T0Iwf0ah0qJHXEIaN0K0yt+lE2hCYi5IWCOESXZf3H4TB+uQ==",
+          "requires": {
+            "babel-helper-builder-binary-assignment-operator-visitor": "7.0.0-alpha.19",
+            "babel-plugin-syntax-exponentiation-operator": "7.0.0-alpha.19"
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-Muw6vf0Hx85mAy8DR00VOPl/oQSxsqDGqEtnp9o8aTrtOg5jNfFZR5IKLz9xawPni2LEf0HerG4iYDSqmvk7NQ==",
+          "requires": {
+            "regenerator-transform": "0.9.11"
+          }
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-xVgVVUQrULvE2ZPtTu9uUYn7z9MC3IeVQ0gwogQzt1aYGm/e0wHvqAVXLyxBZBWMBkOSqoi1tnu58IgmcnP9OQ==",
+          "requires": {
+            "babel-types": "7.0.0-alpha.19"
+          }
+        },
+        "babel-template": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-96IEIj99ubXPjZyF2V/ZZrjSUAO3baNtOP16Qlibd9q5Hh4WVm+Xv2mOqdjABJG96N991EAtNXk3+JibJGxnWQ==",
+          "requires": {
+            "babel-traverse": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19",
+            "babylon": "7.0.0-beta.18",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-nW2yJJjVTKnvmqWSh8jsUAJaQMhTDhD4CPdy7hLhOTxGORPKP+V5ax8wQCHhIbgU+lV2oJ9iqJUpvGvjs7GRwA==",
+          "requires": {
+            "babel-code-frame": "7.0.0-alpha.19",
+            "babel-helper-function-name": "7.0.0-alpha.19",
+            "babel-messages": "7.0.0-alpha.19",
+            "babel-types": "7.0.0-alpha.19",
+            "babylon": "7.0.0-beta.19",
+            "debug": "2.6.8",
+            "globals": "10.1.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "7.0.0-beta.19",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+              "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A=="
+            }
+          }
+        },
+        "babel-types": {
+          "version": "7.0.0-alpha.19",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
+          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "2.0.0"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.18",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.18.tgz",
+          "integrity": "sha1-XCPuP9tmNYqr83iXeTGcW3iiM8c="
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.2.1"
+          }
+        },
+        "globals": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.1.0.tgz",
+          "integrity": "sha1-RCWhiBvg0za0qCOoKnvnJdXdmHw="
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "regexpu-core": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.2.tgz",
+          "integrity": "sha512-qNMZCn1PVlV/T+xBwkHywF7MnOQyUT9EaX4MgAtxOti2hpVZ/8RG+XrVSilTR/5SLH5f3CwB0TtLaGO2M+gUlA==",
+          "requires": {
+            "regenerate": "1.3.2",
+            "regenerate-unicode-properties": "5.1.1",
+            "regjsgen": "0.3.0",
+            "regjsparser": "0.2.1",
+            "unicode-match-property-ecmascript": "1.0.3",
+            "unicode-match-property-value-ecmascript": "1.0.1"
+          }
+        },
+        "regjsgen": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.3.0.tgz",
+          "integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M="
+        },
+        "regjsparser": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.2.1.tgz",
+          "integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+          "requires": {
+            "jsesc": "0.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        }
+      }
+    },
+    "babel-preset-typescript": {
+      "version": "7.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/babel-preset-typescript/-/babel-preset-typescript-7.0.0-alpha.19.tgz",
+      "integrity": "sha512-2VGIgn58ohmVXhc+qAx0OsihQHQm5R+Y1Mu7bu98HbCJtR/CzEdZs8qCtPb1XmYKF8XRNvZQge44dPTVimI2/w==",
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "7.0.0-alpha.19",
+        "babel-plugin-transform-typescript": "7.0.0-alpha.19"
       }
     },
     "babel-runtime": {
@@ -1471,6 +1901,27 @@
         "weinre": "2.0.0-pre-I0Z7U9OV"
       }
     },
+    "browserslist": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.3.tgz",
+      "integrity": "sha512-p9hz6FA2H1w1ZUAXKfK3MlIA4Z9fEd56hnZSOecBIITb5j0oZk/tZRwhdE0xG56RGx2x8cc1c5AWJKWVjMLOEQ==",
+      "requires": {
+        "caniuse-lite": "1.0.30000717",
+        "electron-to-chromium": "1.3.18"
+      },
+      "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30000717",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000717.tgz",
+          "integrity": "sha1-RTmxJq94fB1IUZRN4isr2HgNNhI="
+        },
+        "electron-to-chromium": {
+          "version": "1.3.18",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
+          "integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw="
+        }
+      }
+    },
     "bs-recipes": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
@@ -1652,7 +2103,6 @@
       "requires": {
         "anymatch": "1.3.0",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2559,14 +3009,6 @@
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
       "requires": {
         "fs-exists-sync": "0.1.0"
-      }
-    },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "requires": {
-        "repeating": "2.0.1"
       }
     },
     "detect-newline": {
@@ -3574,791 +4016,6 @@
         "event-emitter": "0.3.5",
         "memoizee": "0.4.5",
         "minimatch": "3.0.4"
-      }
-    },
-    "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-      "optional": true,
-      "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
       }
     },
     "fstream": {
@@ -5484,15 +5141,6 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
-    },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
@@ -6091,9 +5739,9 @@
       "optional": true
     },
     "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -8221,6 +7869,14 @@
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
       "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
     },
+    "regenerate-unicode-properties": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-5.1.1.tgz",
+      "integrity": "sha512-oaZXgyhHR9VYnYFzPRdO+k7tHaUXO5jPqfFYnaC5kIW9NQ0kVwb5rt8x5CEC0LCZ7WRIUy7zIrCF7R2xIbjiRA==",
+      "requires": {
+        "regenerate": "1.3.2"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -8243,36 +7899,6 @@
       "requires": {
         "is-equal-shallow": "0.1.3",
         "is-primitive": "2.0.0"
-      }
-    },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "requires": {
-        "regenerate": "1.3.2",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "requires": {
-        "jsesc": "0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-        }
       }
     },
     "remove-trailing-separator": {
@@ -9042,14 +8668,6 @@
         "resolve-url": "0.2.1",
         "source-map-url": "0.3.0",
         "urix": "0.1.0"
-      }
-    },
-    "source-map-support": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "requires": {
-        "source-map": "0.5.6"
       }
     },
     "source-map-url": {
@@ -9909,6 +9527,30 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.2.tgz",
+      "integrity": "sha512-tIHxB3DR9aS8uArhzIja8y0LQDvWx7DZIRkHJtLPnM29x/m0sNiMF9FYsxIASpkj85qfBvMWBsFURZoHIX6ceA=="
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-nFcaBFcr08UQNF15ZgI5ISh3yUnQm7SJRRxwYrL5VYX46pS+6Q7TCTv4zbK+j6/l7rQt0mMiTL2zpmeygny6rA==",
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "1.0.2",
+        "unicode-property-aliases-ecmascript": "1.0.3"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.1.tgz",
+      "integrity": "sha512-lM8B0FDZQh9yYGgiabRQcyWicB27VLOolSBRIxsO7FeQPtg+79Oe7sC8Mzr8BObDs+G9CeYmC/shHo6OggNEog=="
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-TdDmDOTxEf2ad1g3ZBpM6cqKIb2nJpVlz1Q++casDryKz18tpeMBhSng9hjC1CTQCkOV9Rw2knlSB6iRo7ad1w=="
     },
     "unique-stream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mango-cli",
-  "version": "1.0.0-3",
+  "version": "1.0.0-4",
   "description": "Scaffold and build your projects way more faster than before. Preconfigured frontend devstack to the absolute perfection. Fully automated to save your precious time. Ready for any type of web project.",
   "main": "index.js",
   "scripts": {
@@ -47,12 +47,13 @@
   "dependencies": {
     "asap": "^2.0.6",
     "autoprefixer": "^7.1.2",
-    "babel-core": "^6.22.1",
-    "babel-plugin-transform-class-properties": "^6.22.0",
+    "babel-core": "^v7.0.0-alpha.19",
+    "babel-plugin-transform-class-properties": "^v7.0.0-alpha.19",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-object-rest-spread": "^6.22.0",
-    "babel-plugin-transform-react-jsx": "^6.22.0",
-    "babel-preset-latest": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^v7.0.0-alpha.19",
+    "babel-plugin-transform-react-jsx": "^v7.0.0-alpha.19",
+    "babel-preset-typescript": "^v7.0.0-alpha.19",
+    "babel-preset-env": "^v2.0.0-alpha.16",
     "better-console": "^1.0.0",
     "browser-sync": "^2.18.13",
     "chokidar": "^1.6.1",


### PR DESCRIPTION
Těch alf se vůbec nebojím ‒ jak jsem už někde psal, Babel je i v alfě jedna z nejspolehlivějších závislostí, které tu máme. Potenciální problém bych viděl spíš ve změně z deprecated `babel-preset-latest` na nyní podporované `babel-preset-env`, tam to možná v nějakém pluginu za nějakých obskurních okolností něco udělá. Zkusil jsem si ale na této verzi zbuildit Darujme, poměrně pečlivě si to proklikal a nenalezl žádnou chybu.