### PR TITLE
Replace sharp with jimp module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_install:
     fi
   - if [ $TRAVIS_OS_NAME == "osx" ]; then
       brew update;
-      brew install vips --with-webp --with-graphicsmagick;
       brew install python;
       export PATH="/usr/local/opt/python/libexec/bin:$PATH";
       export TMPDIR="/tmp/";

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm install -g mango-cli
 
 Just a few requirements you already have: latest [Node.js](http://nodejs.org) and [Git](http://git-scm.com) executable in `PATH`.
 
-If you are running __Windows__, there are even some more [special requirements because of node-gyp](https://github.com/TooTallNate/node-gyp).<br>On __OS X__ you can come across a problem with missing vips library. Follow these [instructions](http://sharp.dimens.io/en/stable/install/#mac-os) in sharp module docs.
+If you are running __Windows__, there are even some more [special requirements because of node-gyp](https://github.com/TooTallNate/node-gyp).
 
 If you're still having problems with the installation, check out prepared [release packages](https://github.com/manGoweb/mango-cli/releases). Extract them locally and run `npm link` in the `mango-cli` folder.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -82,7 +82,7 @@ All options can be overridden in `mango.local.yaml` (or `mango.local.json`) file
         * `src` - string (glob) source of images
         * `sizes` - array of widths (int)
         * `aspectRatio` - aspect ratio of image on output (float = width/height), if undefined or false aspect ratio of image is used
-        * `options` - [output options](http://sharp.dimens.io/en/stable/api-output/#jpeg) for [sharp](http://sharp.dimens.io/en/stable/) resizing engine
+        * `quality` - jpeg quality 0-100
 
 ---
 

--- a/lib/tasks/images.js
+++ b/lib/tasks/images.js
@@ -97,6 +97,9 @@ module.exports = function(gulp, config) {
 									callback(null, file)
 								})
 						})
+						.catch(function(err) {
+							console.error(err)
+						})
 				} else {
 					callback(null, file)
 				}

--- a/lib/tasks/images.js
+++ b/lib/tasks/images.js
@@ -7,10 +7,10 @@ module.exports = function(gulp, config) {
 		c.info('~ images')
 
 		var imagemin = require('gulp-imagemin')
-		var plumber = require('gulp-plumber')
+		var jimp = require('jimp')
 		var merge = require('merge-stream')
-		var sharp = require('sharp')
 		var path = require('path')
+		var plumber = require('gulp-plumber')
 		var stream = require('stream')
 
 		var task = merge()
@@ -66,8 +66,8 @@ module.exports = function(gulp, config) {
 						fileClone.path = path.join(name.dir, name.name + '-' + size + name.ext)
 						fileClone.imageTransform = {
 							width: size,
-							height: file.imageData.aspectRatio ? Math.ceil(size/file.imageData.aspectRatio) : null,
-							options: file.imageData.options || {},
+							height: file.imageData.aspectRatio ? Math.ceil(size/file.imageData.aspectRatio) : jimp.AUTO,
+							quality: file.imageData.quality || 90,
 						}
 						this.push(fileClone)
 					}
@@ -85,11 +85,18 @@ module.exports = function(gulp, config) {
 			var transformStream = new stream.Transform({objectMode: true});
 			transformStream._transform = function (file, encoding, callback) {
 				if(file.imageTransform) {
-					sharp(file.contents).resize(file.imageTransform.width, file.imageTransform.height).withoutEnlargement().jpeg(file.imageTransform.options).toBuffer(function (err, buffer, info) {
-						if(err) console.error(err)
-						file.contents = buffer
-						callback(null, file)
-					})
+					jimp
+						.read(file.contents)
+						.then(function(image) {
+							image
+								.resize(file.imageTransform.width, file.imageTransform.height)
+								.quality(image.quality)
+								.getBuffer(jimp.AUTO, function(err, buffer) {
+									if(err) console.error(err)
+									file.contents = buffer
+									callback(null, file)
+								})
+						})
 				} else {
 					callback(null, file)
 				}

--- a/lib/tasks/images.js
+++ b/lib/tasks/images.js
@@ -90,7 +90,7 @@ module.exports = function(gulp, config) {
 						.then(function(image) {
 							image
 								.resize(file.imageTransform.width, file.imageTransform.height)
-								.quality(image.quality)
+								.quality(file.imageTransform.quality)
 								.getBuffer(jimp.AUTO, function(err, buffer) {
 									if(err) console.error(err)
 									file.contents = buffer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,6 +1104,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
+    "bignumber.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.4.0.tgz",
+      "integrity": "sha1-g4qZLan51zfg9LLbC+YrsJ3Qxeg="
+    },
     "bin-build": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz",
@@ -1219,6 +1224,11 @@
       "requires": {
         "inherits": "2.0.3"
       }
+    },
+    "bmp-js": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.0.3.tgz",
+      "integrity": "sha1-ZBE+nHzxICs3btYHvzBibr5XsYo="
     },
     "boolbase": {
       "version": "1.0.0",
@@ -1356,6 +1366,11 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-equal": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
     },
     "buffer-from": {
       "version": "0.1.1",
@@ -1823,11 +1838,6 @@
         }
       }
     },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
-    },
     "clap": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
@@ -2029,15 +2039,6 @@
         "object-visit": "1.0.1"
       }
     },
-    "color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-2.0.0.tgz",
-      "integrity": "sha1-4MmXLR6WmFcASxAeqlXOq1lh1n0=",
-      "requires": {
-        "color-convert": "1.9.1",
-        "color-string": "1.5.2"
-      }
-    },
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -2050,15 +2051,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "color-string": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
-      "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
-      "requires": {
-        "color-name": "1.1.3",
-        "simple-swizzle": "0.2.2"
-      }
     },
     "color-support": {
       "version": "1.1.3",
@@ -2143,15 +2135,6 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
-      }
-    },
-    "config-chain": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
-      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-      "requires": {
-        "ini": "1.3.5",
-        "proto-list": "1.2.4"
       }
     },
     "connect": {
@@ -2735,14 +2718,6 @@
         }
       }
     },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "requires": {
-        "mimic-response": "1.0.0"
-      }
-    },
     "decompress-tar": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
@@ -3052,11 +3027,6 @@
         "fs-exists-sync": "0.1.0"
       }
     },
-    "detect-libc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-0.2.0.tgz",
-      "integrity": "sha1-R/31ZzSKF+wl/L8LnkRjSKdvn7U="
-    },
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -3093,6 +3063,11 @@
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "domelementtype": {
       "version": "1.3.0",
@@ -3696,6 +3671,11 @@
         "meow": "3.7.0"
       }
     },
+    "exif-parser": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
+      "integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI="
+    },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -3988,6 +3968,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
+    },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "requires": {
+        "is-function": "1.0.1"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -5103,6 +5091,15 @@
         "find-index": "0.1.1"
       }
     },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
+      }
+    },
     "global-modules": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
@@ -6179,8 +6176,7 @@
     "ip-regex": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
-      "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=",
-      "optional": true
+      "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0="
     },
     "irregular-plurals": {
       "version": "1.4.0",
@@ -6368,6 +6364,11 @@
         "number-is-nan": "1.0.1"
       }
     },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+    },
     "is-function-x": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
@@ -6476,11 +6477,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-    },
-    "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
     },
     "is-object-like-x": {
       "version": "1.6.0",
@@ -6703,14 +6699,45 @@
         "textextensions": "1.0.2"
       }
     },
-    "isurl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+    "jimp": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.28.tgz",
+      "integrity": "sha1-3VKak3GQ9ClXp5N9Gsw6d2KZbqI=",
       "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
+        "bignumber.js": "2.4.0",
+        "bmp-js": "0.0.3",
+        "es6-promise": "3.3.1",
+        "exif-parser": "0.1.12",
+        "file-type": "3.9.0",
+        "jpeg-js": "0.2.0",
+        "load-bmfont": "1.3.0",
+        "mime": "1.3.4",
+        "mkdirp": "0.5.1",
+        "pixelmatch": "4.0.2",
+        "pngjs": "3.3.1",
+        "read-chunk": "1.0.1",
+        "request": "2.81.0",
+        "stream-to-buffer": "0.1.0",
+        "tinycolor2": "1.4.1",
+        "url-regex": "3.2.0"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+        },
+        "file-type": {
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+        }
       }
+    },
+    "jpeg-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.2.0.tgz",
+      "integrity": "sha1-U+RI7J0mPmgyZkZ+lELSxaLvVII="
     },
     "jpegtran-bin": {
       "version": "3.2.0",
@@ -6912,6 +6939,20 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz",
       "integrity": "sha512-JIKZ0xb6fZZYa3deZ0BgXCgX6HgV8Nx3mFGeFHmFWW8Fb2c08e0CyE+G3nalpD0xGvGssjGb1UdFr+PprxZEbw=="
+    },
+    "load-bmfont": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.3.0.tgz",
+      "integrity": "sha1-u358cQ3mvK/LE8s7jIHgwBMey8k=",
+      "requires": {
+        "buffer-equal": "0.0.1",
+        "mime": "1.3.4",
+        "parse-bmfont-ascii": "1.0.6",
+        "parse-bmfont-binary": "1.0.6",
+        "parse-bmfont-xml": "1.1.3",
+        "xhr": "2.4.1",
+        "xtend": "4.0.1"
+      }
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -7540,10 +7581,13 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
-    "mimic-response": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
-      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -7557,29 +7601,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
-    "minipass": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz",
-      "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
-      "requires": {
-        "yallist": "3.0.2"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
-        }
-      }
-    },
-    "minizlib": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.3.tgz",
-      "integrity": "sha1-1cGr93vhVGGZUuJTM27Mq5sqMvU=",
-      "requires": {
-        "minipass": "2.2.1"
-      }
     },
     "mixin-deep": {
       "version": "1.3.0",
@@ -8001,22 +8022,6 @@
         "white-space-x": "3.0.0"
       }
     },
-    "npm-conf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.2.tgz",
-      "integrity": "sha512-dotwbpwVzfNB/2EF3A2wjK5tEMLggKfuA/8TG6WvBB1Zrv+JsvF7E8ei9B/HGq211st/GwXFbREcNJvJ1eySUQ==",
-      "requires": {
-        "config-chain": "1.1.11",
-        "pify": "3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -8378,6 +8383,25 @@
         "no-case": "2.3.2"
       }
     },
+    "parse-bmfont-ascii": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
+      "integrity": "sha1-Eaw8P/WPfCAgqyJ2kHkQjU36AoU="
+    },
+    "parse-bmfont-binary": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
+      "integrity": "sha1-0Di0dtPp3Z2x4RoLDlOiJ5K2kAY="
+    },
+    "parse-bmfont-xml": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.3.tgz",
+      "integrity": "sha1-1rZqNxr9OcUAfZ8O6yYqTyzOe3w=",
+      "requires": {
+        "xml-parse-from-string": "1.0.1",
+        "xml2js": "0.4.19"
+      }
+    },
     "parse-filepath": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
@@ -8397,6 +8421,15 @@
         "is-dotfile": "1.0.3",
         "is-extglob": "1.0.0",
         "is-glob": "2.0.1"
+      }
+    },
+    "parse-headers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
+      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+      "requires": {
+        "for-each": "0.3.2",
+        "trim": "0.0.1"
       }
     },
     "parse-int-x": {
@@ -8660,6 +8693,14 @@
         "pinkie": "2.0.4"
       }
     },
+    "pixelmatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
+      "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
+      "requires": {
+        "pngjs": "3.3.1"
+      }
+    },
     "plugin-error": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
@@ -8713,6 +8754,11 @@
       "requires": {
         "irregular-plurals": "1.4.0"
       }
+    },
+    "pngjs": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.1.tgz",
+      "integrity": "sha512-ggXCTsqHRIsGMkHlCEhbHhUmNTA2r1lpkE0NL4Q9S8spkXbm4vE9TVmPso2AGYn90Gltdz8W5CyzhcIGg2Gejg=="
     },
     "portscanner": {
       "version": "2.1.1",
@@ -8955,6 +9001,11 @@
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -8982,11 +9033,6 @@
         "to-object-x": "1.5.0",
         "to-property-key-x": "2.0.2"
       }
-    },
-    "proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
     },
     "prr": {
       "version": "0.0.0",
@@ -9232,6 +9278,11 @@
         "pinkie-promise": "2.0.1",
         "readable-stream": "2.3.3"
       }
+    },
+    "read-chunk": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz",
+      "integrity": "sha1-X2jKswfmY/GZk1J9m1icrORmEZQ="
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -10099,58 +10150,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
       "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
     },
-    "sharp": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.18.4.tgz",
-      "integrity": "sha1-/jKcDwaJbCiqJDdt8f/wKuV/LTQ=",
-      "requires": {
-        "caw": "2.0.1",
-        "color": "2.0.0",
-        "detect-libc": "0.2.0",
-        "nan": "2.6.2",
-        "semver": "5.4.1",
-        "simple-get": "2.7.0",
-        "tar": "3.2.1"
-      },
-      "dependencies": {
-        "caw": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
-          "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
-          "requires": {
-            "get-proxy": "2.1.0",
-            "isurl": "1.0.0",
-            "tunnel-agent": "0.6.0",
-            "url-to-options": "1.0.1"
-          }
-        },
-        "get-proxy": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
-          "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
-          "requires": {
-            "npm-conf": "1.1.2"
-          }
-        },
-        "tar": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-3.2.1.tgz",
-          "integrity": "sha512-ZSzds1E0IqutvMU8HxjMaU8eB7urw2fGwTq88ukDOVuUIh0656l7/P7LiVPxhO5kS4flcRJQk8USG+cghQbTUQ==",
-          "requires": {
-            "chownr": "1.0.1",
-            "minipass": "2.2.1",
-            "minizlib": "1.0.3",
-            "mkdirp": "0.5.1",
-            "yallist": "3.0.2"
-          }
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
-        }
-      }
-    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -10232,36 +10231,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
-    "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
-    },
-    "simple-get": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
-      "integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
-      "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
-      }
-    },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "requires": {
-        "is-arrayish": "0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
-          "integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0="
-        }
-      }
     },
     "slash": {
       "version": "1.0.0",
@@ -10740,6 +10709,19 @@
       "requires": {
         "commander": "2.12.2",
         "limiter": "1.1.2"
+      }
+    },
+    "stream-to": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-to/-/stream-to-0.2.2.tgz",
+      "integrity": "sha1-hDBgmNhf25kLn6MAsbPM9V6O8B0="
+    },
+    "stream-to-buffer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-to-buffer/-/stream-to-buffer-0.1.0.tgz",
+      "integrity": "sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=",
+      "requires": {
+        "stream-to": "0.2.2"
       }
     },
     "streamfilter": {
@@ -11391,6 +11373,11 @@
         "next-tick": "1.0.0"
       }
     },
+    "tinycolor2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
+      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+    },
     "to-absolute-glob": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
@@ -11615,6 +11602,11 @@
       "requires": {
         "punycode": "1.4.1"
       }
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-left-x": {
       "version": "3.0.0",
@@ -11920,15 +11912,9 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
       "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
-      "optional": true,
       "requires": {
         "ip-regex": "1.0.3"
       }
-    },
-    "url-to-options": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "use": {
       "version": "2.0.2",
@@ -12392,10 +12378,40 @@
         "ultron": "1.1.1"
       }
     },
+    "xhr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
+      "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
+      "requires": {
+        "global": "4.3.2",
+        "is-function": "1.0.1",
+        "parse-headers": "2.0.1",
+        "xtend": "4.0.1"
+      }
+    },
     "xml-char-classes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
       "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0="
+    },
+    "xml-parse-from-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
+      "integrity": "sha1-qQKekp09vN7RafPG4oI42VpdWig="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.4"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
     },
     "xmldom": {
       "version": "0.1.27",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "gulp-stylus": "^2.7.0",
     "gulp-svg-sprite": "^1.3.7",
     "gulp-uglify-es": "^0.1.9",
+    "jimp": "^0.2.28",
     "js-yaml": "^3.10.0",
     "jsonfile": "^4.0.0",
     "lodash": "^4.17.4",
@@ -102,7 +103,6 @@
     "rollup-plugin-yaml": "^1.1.0",
     "run-sequence": "^2.2.0",
     "semver": "^5.4.1",
-    "sharp": "^0.18.4",
     "v8-compile-cache": "^1.1.0",
     "vue-template-compiler": "^2.5.13"
   },


### PR DESCRIPTION
- uses https://github.com/oliver-moran/jimp and streams
- removes libvips dependency
- simplifies installation process
- works on Node 9
- adds more overhead to the resize process (it takes more memory and time to resize images)

**Todos**
- [ ] Never distort an image and keep original aspect ratio by cropping it
- [ ] Notify about options are no longer available

Opinions? Can you please test it if it works for you?

Thanks ❤️ 

---

Fixes #187, closes #190, see #180
  
  
  